### PR TITLE
Fix static variable in CoffeeScript variant

### DIFF
--- a/Fruit.coffee
+++ b/Fruit.coffee
@@ -1,12 +1,12 @@
 prompt = require('syncprompt')
-longestName = ""
 class Fruit
+	@longestName = ""
 	@getLongestName: () ->
-		return longestName
+		return Fruit.longestName
 	constructor: (name, colour) ->
 		@name = name
-		if @name.length > longestName.length
-			longestName = @name
+		if @name.length > Fruit.longestName.length
+			Fruit.longestName = @name
 		@colour = colour
 	getName: () ->
 		return @.name


### PR DESCRIPTION
Turns out Coffeescript does support static variables. This pull request just switches the Coffeescript version over to use it, losing the global longestName variable which we no longer need.

It means it's no longer an exact port of the JS version (since as you said, ECMAScript 2015 has no static variables), but I figure that's no bad thing in that you may as well use language features where they do exist.